### PR TITLE
#9: support for usernames with uppercase characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,6 @@ XMPP_UPDATE_VCARD_HOURS
 A note on usernames
 -------------------
 
-Jabber IDs are case-insensitive (so "MyUser@domain.com" and "myuser@domain.com" are the same account). By contrast, the ``username`` field in the default Django ``User`` model is case-sensitive (see `this Django ticket <https://code.djangoproject.com/ticket/2273>`_). This means two separate "MyUser" and "myuser" accounts in Django will have the same JID on the XMPP server. The ``ejabberd_auth`` management command will not authenticate such users, and they will both see "Authentication failed" in the Converse client.
+Jabber IDs are case-insensitive (so "MyUser@domain.com" and "myuser@domain.com" are the same account). By contrast, the ``username`` field in the default Django ``User`` model is case-sensitive (see `this Django ticket <https://code.djangoproject.com/ticket/2273>`_). This means two separate "MyUser" and "myuser" accounts in Django will have the same JID on the XMPP server. The ``ejabberd_auth`` management command will not authenticate such users, and they will both see "Authentication failed" in Converse and other XMPP clients.
 
 To avoid such conflicts, it is recommended to use a custom ``User`` model that enforces unique lowercase usernames with a ``RegexField``. Other characters not allowed in a Jabber ID should be excluded as well. See `this guide <http://archive.jabber.org/userguide/#register>`_ for details.

--- a/README.rst
+++ b/README.rst
@@ -132,3 +132,10 @@ XMPP_UPDATE_VCARD
 
 XMPP_UPDATE_VCARD_HOURS
     Update vCard every n hours (default False)
+
+A note on usernames
+-------------------
+
+Jabber IDs are case-insensitive (so "MyUser@domain.com" and "myuser@domain.com" are the same account). By contrast, the ``username`` field in the default Django ``User`` model is case-sensitive (see `this Django ticket <https://code.djangoproject.com/ticket/2273>`_). This means two separate "MyUser" and "myuser" accounts in Django will have the same JID on the XMPP server. The ``ejabberd_auth`` management command will not authenticate such users, and they will both see "Authentication failed" in the Converse client.
+
+To avoid such conflicts, it is recommended to use a custom ``User`` model that enforces unique lowercase usernames with a ``RegexField``. Other characters not allowed in a Jabber ID should be excluded as well. See `this guide <http://archive.jabber.org/userguide/#register>`_ for details.

--- a/xmpp/management/commands/ejabberd_auth.py
+++ b/xmpp/management/commands/ejabberd_auth.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         self.logger.debug("Authenticating %s with password %s on server %s" % (username, password, server))
         try:
             # First try authenticating with generated webapp account password
-            xmpp_account = XMPPAccount.objects.get(user__username=username, password=password)
+            xmpp_account = XMPPAccount.objects.get(user__username__iexact=username, password=password)
             user = xmpp_account.user
             self.logger.info("Authenticated account %s with webapp XMPPAccount" % username)
         except XMPPAccount.DoesNotExist:
@@ -70,7 +70,7 @@ class Command(BaseCommand):
         """
         self.logger.debug("Validating %s on server %s" % (username, server))
         try:
-            user = get_user_model().objects.get(username=username)
+            user = get_user_model().objects.get(username__iexact=username)
             if user.is_active:
                 return True
             else:
@@ -85,7 +85,7 @@ class Command(BaseCommand):
         """
         self.logger.debug("Changing password to %s with new password %s on server %s" % (username, password, server))
         try:
-            user = get_user_model().objects.get(username=username)
+            user = get_user_model().objects.get(username__iexact=username)
             user.set_password(password)
             user.save()
             return True


### PR DESCRIPTION
The problem with a username like "FooBar" is that even if it is included like that in the JID used by Converse ("FooBar@domain.com"), ejabberd still passes the lowercase version ("foobar") to the external auth script, which of course fails. I switched to a case-insensitive query to resolve this problem.

**WARNING:** the default `username` field in Django's `User` model is case-sensitive. So in most applications it is actually possible to have two users ("FooBar" and "foobar") with the same JID. The current query can authenticate the wrong user. My query will fail with `MultipleObjectsReturned` in this case (which I think is correct). @fpytloun : if you're fine with this, I can add a note about usernames in the README.
